### PR TITLE
Add initial Chandler Legacy View Home Assistant integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,42 @@
-# ha-chandler-legacy-view
-Home Assistant integration for Bluetooth-connected water system valves
+# Chandler Legacy View Home Assistant Integration
+
+The Chandler Legacy View project is a Home Assistant custom integration that
+focuses on water system valves such as water softeners and filtration systems.
+The integration listens for Bluetooth advertisements emitted by supported
+valves, recognises them by their signatures, and surfaces their presence inside
+Home Assistant as entities that can participate in automations or dashboards.
+
+## Current capabilities
+
+* Establishes a Home Assistant config entry via the UI (no YAML required).
+* Watches for Bluetooth advertisements that match the expected Chandler valve
+  signatures.
+* Creates binary sensor entities that indicate whether each recognised valve is
+  currently available.
+
+This repository currently focuses on the scaffolding required for discovery and
+entity creation. Additional device metadata, richer entities, diagnostics, and
+configuration options will follow as device details become available.
+
+## Installation
+
+1. Copy the `custom_components/chandler_legacy_view` directory into your Home
+   Assistant `custom_components` folder.
+2. Restart Home Assistant to load the new integration.
+3. In Home Assistant, navigate to **Settings → Devices & Services → Add
+   Integration** and search for "Chandler Legacy View".
+4. Complete the configuration flow to enable Bluetooth-based discovery of
+   Chandler valves. Only one instance of the integration is required.
+
+## Development
+
+* `custom_components/chandler_legacy_view/discovery.py` implements the Bluetooth
+  discovery logic.
+* `custom_components/chandler_legacy_view/binary_sensor.py` defines the initial
+  entity type exposed by the integration.
+* Configuration flow strings are located in
+  `custom_components/chandler_legacy_view/translations/en.json`.
+
+Contributions are welcome! The goal is to expand the integration to expose the
+valve state (e.g. service mode, regeneration cycles) and diagnostics as the
+device protocol becomes better understood.

--- a/custom_components/chandler_legacy_view/__init__.py
+++ b/custom_components/chandler_legacy_view/__init__.py
@@ -1,0 +1,59 @@
+"""The Chandler Legacy View integration."""
+
+from __future__ import annotations
+
+import logging
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.typing import ConfigType
+
+from .const import DATA_DISCOVERY_MANAGER, DOMAIN, PLATFORMS
+from .discovery import ValveDiscoveryManager
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
+    """Set up the Chandler Legacy View integration via YAML."""
+
+    hass.data.setdefault(DOMAIN, {})
+    return True
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Set up Chandler Legacy View from a config entry."""
+
+    hass.data.setdefault(DOMAIN, {})
+
+    manager = ValveDiscoveryManager(hass)
+    await manager.async_setup()
+
+    hass.data[DOMAIN][entry.entry_id] = {DATA_DISCOVERY_MANAGER: manager}
+
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+
+    entry.async_on_unload(entry.add_update_listener(async_reload_entry))
+    _LOGGER.debug("Chandler Legacy View setup complete for entry %s", entry.entry_id)
+    return True
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Unload a Chandler Legacy View config entry."""
+
+    unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+
+    data = hass.data[DOMAIN].pop(entry.entry_id, None)
+    if data is not None:
+        await data[DATA_DISCOVERY_MANAGER].async_unload()
+
+    if not hass.data[DOMAIN]:
+        hass.data.pop(DOMAIN)
+
+    return unload_ok
+
+
+async def async_reload_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
+    """Handle a config entry reload request."""
+
+    await hass.config_entries.async_reload(entry.entry_id)

--- a/custom_components/chandler_legacy_view/binary_sensor.py
+++ b/custom_components/chandler_legacy_view/binary_sensor.py
@@ -1,0 +1,97 @@
+"""Binary sensor platform for Chandler Legacy water system valves."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+from homeassistant.components.binary_sensor import (
+    BinarySensorDeviceClass,
+    BinarySensorEntity,
+)
+from homeassistant.components.bluetooth import BluetoothChange
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import DATA_DISCOVERY_MANAGER, DOMAIN
+from .discovery import ValveDiscoveryManager
+from .entity import ChandlerValveEntity
+from .models import ValveAdvertisement
+
+
+class ValvePresenceBinarySensor(ChandlerValveEntity, BinarySensorEntity):
+    """Represent the presence of a water system valve detected via Bluetooth."""
+
+    _attr_device_class = BinarySensorDeviceClass.PRESENCE
+
+    def __init__(self, advertisement: ValveAdvertisement) -> None:
+        super().__init__(advertisement)
+        self._attr_is_on = True
+        self._attr_available = True
+
+    @callback
+    def async_handle_bluetooth_update(
+        self, advertisement: ValveAdvertisement, change: BluetoothChange
+    ) -> None:
+        """Handle updates from the Bluetooth discovery manager."""
+
+        if change is BluetoothChange.LOST:
+            self._attr_is_on = False
+            self._attr_available = False
+        else:
+            self._attr_is_on = True
+            self.async_update_from_advertisement(advertisement)
+            self._attr_available = True
+        self.async_write_ha_state()
+
+    @property
+    def extra_state_attributes(self) -> Mapping[str, int | str]:
+        """Provide metadata about the most recent advertisement."""
+
+        attributes: dict[str, int | str] = {}
+        if self._advertisement.rssi is not None:
+            attributes["rssi"] = self._advertisement.rssi
+        if self._advertisement.name:
+            attributes["advertised_name"] = self._advertisement.name
+        return attributes
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up valve presence binary sensors from a config entry."""
+
+    entry_data = hass.data[DOMAIN][entry.entry_id]
+    manager: ValveDiscoveryManager = entry_data[DATA_DISCOVERY_MANAGER]
+    entities: dict[str, ValvePresenceBinarySensor] = {}
+
+    initial_entities = [
+        ValvePresenceBinarySensor(advertisement)
+        for advertisement in manager.devices.values()
+    ]
+    for entity in initial_entities:
+        entities[entity.unique_id] = entity
+
+    if initial_entities:
+        async_add_entities(initial_entities)
+
+    @callback
+    def _handle_discovery(
+        advertisement: ValveAdvertisement, change: BluetoothChange
+    ) -> None:
+        entity = entities.get(advertisement.address)
+        if entity is not None:
+            entity.async_handle_bluetooth_update(advertisement, change)
+            return
+
+        if change is BluetoothChange.LOST:
+            return
+
+        new_entity = ValvePresenceBinarySensor(advertisement)
+        entities[advertisement.address] = new_entity
+        async_add_entities([new_entity])
+
+    remove_listener = manager.async_add_listener(_handle_discovery)
+    entry.async_on_unload(remove_listener)

--- a/custom_components/chandler_legacy_view/config_flow.py
+++ b/custom_components/chandler_legacy_view/config_flow.py
@@ -1,0 +1,29 @@
+"""Config flow for the Chandler Legacy View integration."""
+
+from __future__ import annotations
+
+import voluptuous as vol
+
+from homeassistant import config_entries
+from homeassistant.data_entry_flow import FlowResult
+
+from .const import DOMAIN
+
+
+class ChandlerLegacyViewConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
+    """Handle a config flow for Chandler Legacy View."""
+
+    VERSION = 1
+
+    async def async_step_user(
+        self, user_input: dict[str, object] | None = None
+    ) -> FlowResult:
+        """Handle the initial step initiated by the user."""
+
+        if self._async_current_entries():
+            return self.async_abort(reason="single_instance_allowed")
+
+        if user_input is None:
+            return self.async_show_form(step_id="user", data_schema=vol.Schema({}))
+
+        return self.async_create_entry(title="Chandler Legacy View", data={})

--- a/custom_components/chandler_legacy_view/const.py
+++ b/custom_components/chandler_legacy_view/const.py
@@ -1,0 +1,25 @@
+"""Constants for the Chandler Legacy View integration."""
+
+from __future__ import annotations
+
+from typing import Final
+
+from homeassistant.const import Platform
+
+DOMAIN: Final = "chandler_legacy_view"
+PLATFORMS: Final[list[Platform]] = [Platform.BINARY_SENSOR]
+
+# Storage keys used inside ``hass.data``
+DATA_DISCOVERY_MANAGER: Final = "discovery_manager"
+
+# Default presentation details for discovered devices
+DEFAULT_DEVICE_NAME: Final = "Water System Valve"
+DEFAULT_MANUFACTURER: Final = "Chandler"
+
+# Bluetooth callback matchers describing the devices we are interested in.
+# These are placeholders that document the expected shape of the data and can be
+# updated once precise manufacturer or service identifiers are known.
+VALVE_MATCHERS: Final = (
+    {"local_name": "Chandler Softener"},
+    {"local_name": "Chandler Filter"},
+)

--- a/custom_components/chandler_legacy_view/discovery.py
+++ b/custom_components/chandler_legacy_view/discovery.py
@@ -1,0 +1,100 @@
+"""Bluetooth discovery support for Chandler Legacy water system valves."""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable
+from typing import Dict
+
+from homeassistant.components.bluetooth import (
+    BluetoothChange,
+    BluetoothScanningMode,
+    BluetoothServiceInfoBleak,
+    async_register_callback,
+)
+from homeassistant.core import CALLBACK_TYPE, HomeAssistant
+
+from .const import VALVE_MATCHERS
+from .models import ValveAdvertisement
+
+_LOGGER = logging.getLogger(__name__)
+
+ValveListener = Callable[[ValveAdvertisement, BluetoothChange], None]
+
+
+class ValveDiscoveryManager:
+    """Track Bluetooth advertisements originating from known valves."""
+
+    def __init__(self, hass: HomeAssistant) -> None:
+        """Initialize the manager."""
+
+        self._hass = hass
+        self._callbacks: list[CALLBACK_TYPE] = []
+        self._listeners: list[ValveListener] = []
+        self._devices: Dict[str, ValveAdvertisement] = {}
+
+    async def async_setup(self) -> None:
+        """Start listening for Bluetooth advertisements."""
+
+        _LOGGER.debug("Setting up Bluetooth discovery for Chandler valves")
+        self._callbacks.append(
+            async_register_callback(
+                self._hass,
+                self._async_handle_bluetooth_event,
+                VALVE_MATCHERS,
+                BluetoothScanningMode.PASSIVE,
+            )
+        )
+
+    async def async_unload(self) -> None:
+        """Cancel Bluetooth callbacks and clear tracked devices."""
+
+        _LOGGER.debug("Unloading Bluetooth discovery for Chandler valves")
+        while self._callbacks:
+            remove = self._callbacks.pop()
+            remove()
+        self._listeners.clear()
+        self._devices.clear()
+
+    @property
+    def devices(self) -> Dict[str, ValveAdvertisement]:
+        """Return a snapshot of the tracked devices."""
+
+        return dict(self._devices)
+
+    def async_add_listener(self, listener: ValveListener) -> CALLBACK_TYPE:
+        """Register a listener that is notified when a valve advertisement is seen."""
+
+        self._listeners.append(listener)
+
+        def _remove_listener() -> None:
+            self._listeners.remove(listener)
+
+        return _remove_listener
+
+    def _async_handle_bluetooth_event(
+        self, service_info: BluetoothServiceInfoBleak, change: BluetoothChange
+    ) -> None:
+        """Handle an incoming Bluetooth advertisement from Home Assistant."""
+
+        advertisement = ValveAdvertisement(
+            address=service_info.address,
+            name=service_info.name,
+            rssi=service_info.rssi,
+            manufacturer_data=service_info.manufacturer_data,
+            service_data=service_info.service_data,
+        )
+
+        if change is BluetoothChange.LOST:
+            self._devices.pop(service_info.address, None)
+            _LOGGER.debug("Valve %s lost", service_info.address)
+        else:
+            self._devices[service_info.address] = advertisement
+            _LOGGER.debug(
+                "Valve %s seen (RSSI=%s)",
+                service_info.address,
+                service_info.rssi,
+            )
+
+        for listener in list(self._listeners):
+            listener(advertisement, change)

--- a/custom_components/chandler_legacy_view/entity.py
+++ b/custom_components/chandler_legacy_view/entity.py
@@ -1,0 +1,48 @@
+"""Base entities for the Chandler Legacy View integration."""
+
+from __future__ import annotations
+
+from homeassistant.helpers.entity import DeviceInfo, Entity
+
+from .const import DEFAULT_DEVICE_NAME, DEFAULT_MANUFACTURER, DOMAIN
+from .models import ValveAdvertisement
+
+
+class ChandlerValveEntity(Entity):
+    """Base entity shared by Chandler Legacy valve platforms."""
+
+    _attr_has_entity_name = True
+    _attr_should_poll = False
+
+    def __init__(self, advertisement: ValveAdvertisement) -> None:
+        """Initialize the entity."""
+
+        self._advertisement = advertisement
+        self._attr_unique_id = advertisement.address
+        self._attr_name = self._compute_name(advertisement)
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Return metadata for the device registry."""
+
+        return DeviceInfo(
+            identifiers={(DOMAIN, self._advertisement.address)},
+            name=self._compute_name(self._advertisement),
+            manufacturer=DEFAULT_MANUFACTURER,
+            via_device=(DOMAIN, "bluetooth"),
+        )
+
+    def async_update_from_advertisement(self, advertisement: ValveAdvertisement) -> None:
+        """Store the most recent advertisement seen for this valve."""
+
+        self._advertisement = advertisement
+        self._attr_name = self._compute_name(advertisement)
+
+    def _compute_name(self, advertisement: ValveAdvertisement) -> str:
+        """Generate a user-friendly name for the valve entity."""
+
+        if advertisement.name:
+            return advertisement.name
+
+        address_fragment = advertisement.address.replace(":", "")[-4:]
+        return f"{DEFAULT_DEVICE_NAME} {address_fragment.upper()}"

--- a/custom_components/chandler_legacy_view/manifest.json
+++ b/custom_components/chandler_legacy_view/manifest.json
@@ -1,0 +1,14 @@
+{
+  "domain": "chandler_legacy_view",
+  "name": "Chandler Legacy View",
+  "version": "0.1.0",
+  "config_flow": true,
+  "documentation": "https://github.com/chandler-engineering/ha-chandler-legacy-view",
+  "issue_tracker": "https://github.com/chandler-engineering/ha-chandler-legacy-view/issues",
+  "requirements": [],
+  "dependencies": ["bluetooth"],
+  "codeowners": ["@chandler-engineering"],
+  "iot_class": "local_push",
+  "integration_type": "hub",
+  "loggers": ["custom_components.chandler_legacy_view"]
+}

--- a/custom_components/chandler_legacy_view/models.py
+++ b/custom_components/chandler_legacy_view/models.py
@@ -1,0 +1,18 @@
+"""Data models for the Chandler Legacy View integration."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Mapping
+
+
+@dataclass(slots=True)
+class ValveAdvertisement:
+    """Representation of a Bluetooth advertisement emitted by a valve."""
+
+    address: str
+    name: str | None
+    rssi: int | None
+    manufacturer_data: Mapping[int, bytes]
+    service_data: Mapping[str, bytes]
+

--- a/custom_components/chandler_legacy_view/translations/en.json
+++ b/custom_components/chandler_legacy_view/translations/en.json
@@ -1,0 +1,14 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "Chandler Legacy View",
+        "description": "Set up discovery of Chandler Legacy water system valves.",
+        "data": {}
+      }
+    },
+    "abort": {
+      "single_instance_allowed": "Only one Chandler Legacy View configuration is permitted."
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add a Home Assistant custom component skeleton for Chandler Legacy View with manifest, config flow, and setup logic
- implement Bluetooth discovery management and valve presence binary sensors so recognised valves appear as entities
- document the repository goals, current capabilities, and installation steps in the README

## Testing
- `python -m compileall custom_components/chandler_legacy_view`


------
https://chatgpt.com/codex/tasks/task_e_68c9831133108333b2bea81e4dde59a3