### PR TITLE
Add HACS manifest file

### DIFF
--- a/hacs.json
+++ b/hacs.json
@@ -1,0 +1,4 @@
+{
+  "name": "Chandler Legacy View",
+  "render_readme": true
+}


### PR DESCRIPTION
## Summary
- add a `hacs.json` manifest to expose repository metadata to HACS
- allow HACS to validate the repository when installing from a custom source

## Testing
- python -m compileall custom_components/chandler_legacy_view

------
https://chatgpt.com/codex/tasks/task_e_68c9cd804bc88333b6502492f9a795b0