### PR TITLE
Handle Bluetooth lost change compatibility

### DIFF
--- a/custom_components/chandler_legacy_view/binary_sensor.py
+++ b/custom_components/chandler_legacy_view/binary_sensor.py
@@ -14,7 +14,7 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import DATA_DISCOVERY_MANAGER, DOMAIN
-from .discovery import ValveDiscoveryManager
+from .discovery import BLUETOOTH_LOST_CHANGES, ValveDiscoveryManager
 from .entity import ChandlerValveEntity
 from .models import ValveAdvertisement
 
@@ -35,7 +35,7 @@ class ValvePresenceBinarySensor(ChandlerValveEntity, BinarySensorEntity):
     ) -> None:
         """Handle updates from the Bluetooth discovery manager."""
 
-        if change is BluetoothChange.LOST:
+        if change in BLUETOOTH_LOST_CHANGES:
             self._attr_is_on = False
             self._attr_available = False
         else:
@@ -94,7 +94,7 @@ async def async_setup_entry(
             entity.async_handle_bluetooth_update(advertisement, change)
             return
 
-        if change is BluetoothChange.LOST:
+        if change in BLUETOOTH_LOST_CHANGES:
             return
 
         new_entity = ValvePresenceBinarySensor(advertisement)

--- a/custom_components/chandler_legacy_view/discovery.py
+++ b/custom_components/chandler_legacy_view/discovery.py
@@ -25,7 +25,7 @@ _VALVE_NAME_PREFIXES_CASEFOLD = tuple(
     prefix.casefold() for prefix in VALVE_NAME_PREFIXES
 )
 
-_BLUETOOTH_LOST_CHANGES: tuple[BluetoothChange, ...] = tuple(
+BLUETOOTH_LOST_CHANGES: tuple[BluetoothChange, ...] = tuple(
     getattr(BluetoothChange, change_name)
     for change_name in ("LOST", "UNAVAILABLE", "DISCONNECTED")
     if hasattr(BluetoothChange, change_name)
@@ -133,7 +133,7 @@ class ValveDiscoveryManager:
     ) -> None:
         """Handle an incoming Bluetooth advertisement from Home Assistant."""
 
-        if change in _BLUETOOTH_LOST_CHANGES:
+        if change in BLUETOOTH_LOST_CHANGES:
             advertisement = self._devices.pop(service_info.address, None)
             if advertisement is None:
                 _LOGGER.debug(


### PR DESCRIPTION
## Summary
- expose the dynamically detected set of Bluetooth "lost" change values from the discovery module
- update the valve presence binary sensor to rely on the shared tuple instead of BluetoothChange.LOST directly

## Testing
- python -m compileall custom_components/chandler_legacy_view

------
https://chatgpt.com/codex/tasks/task_e_68c9d84a84c08333baa7afa14c21a9a9