### PR TITLE
Create Bluetooth discovery parent device

### DIFF
--- a/custom_components/chandler_legacy_view/__init__.py
+++ b/custom_components/chandler_legacy_view/__init__.py
@@ -6,9 +6,19 @@ import logging
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers.device_registry import DeviceEntryType
 from homeassistant.helpers.typing import ConfigType
 
-from .const import DATA_DISCOVERY_MANAGER, DOMAIN, PLATFORMS
+from .const import (
+    DATA_DISCOVERY_MANAGER,
+    DEFAULT_MANUFACTURER,
+    DISCOVERY_DEVICE_MODEL,
+    DISCOVERY_DEVICE_NAME,
+    DISCOVERY_VIA_DEVICE_ID,
+    DOMAIN,
+    PLATFORMS,
+)
 from .discovery import ValveDiscoveryManager
 
 _LOGGER = logging.getLogger(__name__)
@@ -25,6 +35,16 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Chandler Legacy View from a config entry."""
 
     hass.data.setdefault(DOMAIN, {})
+
+    device_registry = dr.async_get(hass)
+    device_registry.async_get_or_create(
+        config_entry_id=entry.entry_id,
+        identifiers={(DOMAIN, DISCOVERY_VIA_DEVICE_ID)},
+        manufacturer=DEFAULT_MANUFACTURER,
+        model=DISCOVERY_DEVICE_MODEL,
+        name=DISCOVERY_DEVICE_NAME,
+        entry_type=DeviceEntryType.SERVICE,
+    )
 
     manager = ValveDiscoveryManager(hass)
     await manager.async_setup()

--- a/custom_components/chandler_legacy_view/const.py
+++ b/custom_components/chandler_legacy_view/const.py
@@ -17,6 +17,11 @@ DATA_DISCOVERY_MANAGER: Final = "discovery_manager"
 DEFAULT_FRIENDLY_NAME: Final = "Treatment Valve"
 DEFAULT_MANUFACTURER: Final = "Chandler"
 
+# Device registry definitions for the integration's Bluetooth discovery service.
+DISCOVERY_VIA_DEVICE_ID: Final = "bluetooth"
+DISCOVERY_DEVICE_NAME: Final = "Chandler Valve Discovery"
+DISCOVERY_DEVICE_MODEL: Final = "Bluetooth Service"
+
 # Manufacturer data identifier advertised by Chandler Legacy valves.
 CSI_MANUFACTURER_ID: Final = 1850
 

--- a/custom_components/chandler_legacy_view/entity.py
+++ b/custom_components/chandler_legacy_view/entity.py
@@ -7,6 +7,7 @@ from homeassistant.helpers.entity import DeviceInfo, Entity
 from .const import (
     DEFAULT_FRIENDLY_NAME,
     DEFAULT_MANUFACTURER,
+    DISCOVERY_VIA_DEVICE_ID,
     DOMAIN,
     FRIENDLY_NAME_OVERRIDES,
 )
@@ -48,7 +49,7 @@ class ChandlerValveEntity(Entity):
             name=self._compute_name(self._advertisement),
             manufacturer=DEFAULT_MANUFACTURER,
             model=self._advertisement.model,
-            via_device=(DOMAIN, "bluetooth"),
+            via_device=(DOMAIN, DISCOVERY_VIA_DEVICE_ID),
             sw_version=self._format_firmware_version(self._advertisement),
         )
 


### PR DESCRIPTION
## Summary
- register a Bluetooth discovery service device for the integration
- reuse a shared constant when linking valve entities to the parent device

## Testing
- python -m compileall custom_components/chandler_legacy_view

------
https://chatgpt.com/codex/tasks/task_e_68c9da2d01748333968d91e003e915b6