### PR TITLE
Add integration icon

### DIFF
--- a/custom_components/chandler_legacy_view/manifest.json
+++ b/custom_components/chandler_legacy_view/manifest.json
@@ -10,5 +10,6 @@
   "codeowners": ["@sharwell"],
   "iot_class": "local_push",
   "integration_type": "hub",
+  "icon": "custom_components/chandler_legacy_view/icon.png",
   "loggers": ["custom_components.chandler_legacy_view"]
 }


### PR DESCRIPTION
## Summary
- register the uploaded icon with Home Assistant by referencing it from the manifest

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cc5399448c833391d3d1f2a4b8d4aa