### PR TITLE
Only show salt status for supported valves

### DIFF
--- a/custom_components/chandler_legacy_view/binary_sensor.py
+++ b/custom_components/chandler_legacy_view/binary_sensor.py
@@ -20,6 +20,7 @@ from .entity import (
     _VALVE_SERIES_EVB034_DISPLAY,
     _VALVE_SERIES_EBX044_DISPLAY,
     _bypass_status_display,
+    _can_report_low_salt,
     _is_clack_valve,
     _salt_sensor_status_display,
     _valve_error_display,
@@ -61,6 +62,7 @@ class ValvePresenceBinarySensor(ChandlerValveEntity, BinarySensorEntity):
 
         attributes: dict[str, int | str] = {}
         is_clack_valve = _is_clack_valve(self._advertisement.name)
+        can_report_low_salt = _can_report_low_salt(self._advertisement.name)
         if self._advertisement.rssi is not None:
             attributes["rssi"] = self._advertisement.rssi
         if self._advertisement.name:
@@ -95,7 +97,7 @@ class ValvePresenceBinarySensor(ChandlerValveEntity, BinarySensorEntity):
             )
         if self._advertisement.valve_status is not None:
             attributes["valve_status"] = self._advertisement.valve_status
-        if self._advertisement.salt_sensor_status is not None:
+        if can_report_low_salt and self._advertisement.salt_sensor_status is not None:
             attributes["salt_sensor_status"] = (
                 self._advertisement.salt_sensor_status
             )

--- a/custom_components/chandler_legacy_view/entity.py
+++ b/custom_components/chandler_legacy_view/entity.py
@@ -17,6 +17,19 @@ from .models import ValveAdvertisement
 
 
 _CLACK_NAME_PREFIX = "cl_"
+_LOW_SALT_CAPABLE_NAMES = {
+    "CS_Meter_Soft",
+    "CS_C_Meter_Soft",
+    "C2_01",
+    "C2_03",
+    "C2_17",
+    "C2_19",
+    "C2_21",
+    "CL_01",
+    "CL_04",
+    "CL_06",
+    "CL_08",
+}
 _VALVE_ERROR_TIMEOUT_CODE = 7
 
 _VALVE_ERROR_DISPLAY: dict[int, str] = {
@@ -94,6 +107,19 @@ def _is_clack_valve(advertised_name: str | None) -> bool:
     if not advertised_name:
         return False
     return advertised_name.strip().casefold().startswith(_CLACK_NAME_PREFIX)
+
+
+def _can_report_low_salt(advertised_name: str | None) -> bool:
+    """Return ``True`` if the valve can report a low salt condition."""
+
+    if not advertised_name:
+        return False
+
+    normalized_name = advertised_name.strip()
+    if not normalized_name:
+        return False
+
+    return normalized_name in _LOW_SALT_CAPABLE_NAMES
 
 
 def _valve_error_display(error_code: int | None, is_clack_valve: bool) -> str | None:


### PR DESCRIPTION
## Summary
- add helper to identify valves that can report low salt capability by advertised name
- only expose salt status attributes when the valve can report low salt

## Testing
- python -m compileall custom_components/chandler_legacy_view

------
https://chatgpt.com/codex/tasks/task_e_68cc62e522e883338e5dd6a7aa5e8926