### PR TITLE
Add valve connection manager for periodic polling

### DIFF
--- a/custom_components/chandler_legacy_view/binary_sensor.py
+++ b/custom_components/chandler_legacy_view/binary_sensor.py
@@ -26,6 +26,7 @@ from .entity import (
     _valve_error_display,
     _valve_series_display,
     _water_status_display,
+    format_firmware_version,
 )
 from .models import ValveAdvertisement
 
@@ -66,7 +67,7 @@ class ValvePresenceBinarySensor(ChandlerValveEntity, BinarySensorEntity):
             attributes["rssi"] = self._advertisement.rssi
         if self._advertisement.name:
             attributes["advertised_name"] = self._advertisement.name
-        formatted_version = self._format_firmware_version(self._advertisement)
+        formatted_version = format_firmware_version(self._advertisement)
         if formatted_version:
             attributes["firmware_version"] = formatted_version
         if self._advertisement.connection_counter is not None:

--- a/custom_components/chandler_legacy_view/connection.py
+++ b/custom_components/chandler_legacy_view/connection.py
@@ -520,8 +520,9 @@ class ValveConnection:
             )
             return None
 
-        # TODO: Determine whether certain Evb019 valves should be treated as "classic"
-        # models when deciding if a DeviceList packet can contain a serial number.
+        # Chandler Legacy View only targets Evb019 hardware, which always reports
+        # serial numbers through the DeviceList response. Classic firmware variants
+        # handled elsewhere do not apply to this integration.
         serial = "".join(f"{packet[index]:02X}" for index in range(13, 17)).strip()
         if not serial or serial == _DEFAULT_SERIAL_NUMBER:
             return None

--- a/custom_components/chandler_legacy_view/connection.py
+++ b/custom_components/chandler_legacy_view/connection.py
@@ -1,0 +1,259 @@
+"""Active Bluetooth connection management for Chandler valves."""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+from collections.abc import Iterable
+from datetime import datetime
+
+from bleak.backends.client import BaseBleakClient
+from bleak_retry_connector import (
+    BLEAK_RETRY_EXCEPTIONS,
+    BleakClientWithServiceCache,
+    establish_connection,
+)
+from homeassistant.components import bluetooth
+from homeassistant.components.bluetooth import BluetoothChange
+from homeassistant.core import CALLBACK_TYPE, HomeAssistant, callback
+from homeassistant.helpers.event import async_track_time_interval
+from homeassistant.util import dt as dt_util
+
+from .const import CONNECTION_POLL_INTERVAL, CONNECTION_TIMEOUT_SECONDS
+from .discovery import BLUETOOTH_LOST_CHANGES, ValveDiscoveryManager
+from .models import ValveAdvertisement
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class ValveConnection:
+    """Handle an active Bluetooth data poll for a valve."""
+
+    def __init__(self, hass: HomeAssistant, address: str) -> None:
+        """Initialize the valve connection handler."""
+
+        self._hass = hass
+        self._address = address
+        self._advertisement: ValveAdvertisement | None = None
+        self._available = False
+        self._last_seen: datetime | None = None
+        self._last_success: datetime | None = None
+        self._lock = asyncio.Lock()
+        self._unloaded = False
+
+    @property
+    def address(self) -> str:
+        """Return the Bluetooth address of the valve."""
+
+        return self._address
+
+    @property
+    def available(self) -> bool:
+        """Return ``True`` if the valve is currently available for polling."""
+
+        return self._available and not self._unloaded
+
+    @property
+    def last_success(self) -> datetime | None:
+        """Return the timestamp of the last successful poll."""
+
+        return self._last_success
+
+    def update_from_advertisement(self, advertisement: ValveAdvertisement) -> None:
+        """Record the most recent Bluetooth advertisement for the valve."""
+
+        self._advertisement = advertisement
+        self._available = True
+        self._last_seen = dt_util.utcnow()
+
+    def mark_unavailable(self) -> None:
+        """Mark the valve as temporarily unavailable."""
+
+        self._available = False
+
+    def schedule_poll(self) -> None:
+        """Schedule a background poll of the valve."""
+
+        if not self.available:
+            return
+        self._hass.async_create_task(self.async_poll())
+
+    async def async_unload(self) -> None:
+        """Prevent future polls and wait for any active poll to finish."""
+
+        self._unloaded = True
+        async with self._lock:
+            return
+
+    async def async_poll(self) -> None:
+        """Attempt to connect to the valve and fetch additional data."""
+
+        if not self.available:
+            return
+
+        if self._lock.locked():
+            _LOGGER.debug(
+                "Skipping poll for %s; another poll is already running", self._address
+            )
+            return
+
+        async with self._lock:
+            await self._async_poll_locked()
+
+    async def _async_poll_locked(self) -> None:
+        """Perform a Bluetooth connection cycle for the valve."""
+
+        advertisement = self._advertisement
+        if advertisement is None:
+            _LOGGER.debug(
+                "Skipping poll for %s; no advertisement data is available", self._address
+            )
+            return
+
+        ble_device = bluetooth.async_ble_device_from_address(
+            self._hass, self._address, connectable=True
+        )
+        if ble_device is None:
+            _LOGGER.debug(
+                "Bluetooth device %s is not currently connectable", self._address
+            )
+            return
+
+        _LOGGER.debug("Connecting to valve %s to refresh diagnostic data", self._address)
+
+        try:
+            async with asyncio.timeout(CONNECTION_TIMEOUT_SECONDS):
+                client = await establish_connection(
+                    BleakClientWithServiceCache,
+                    ble_device,
+                    self._address,
+                )
+        except asyncio.TimeoutError:
+            _LOGGER.warning(
+                "Timed out while attempting to connect to valve %s", self._address
+            )
+            return
+        except BLEAK_RETRY_EXCEPTIONS as exc:
+            _LOGGER.debug(
+                "Unable to establish Bluetooth connection to valve %s: %s",
+                self._address,
+                exc,
+            )
+            return
+        except Exception:  # pragma: no cover - unexpected errors are logged
+            _LOGGER.exception(
+                "Unexpected error connecting to valve %s", self._address
+            )
+            return
+
+        try:
+            await self._async_fetch_device_information(client)
+        except Exception:  # pragma: no cover - future protocol work may raise
+            _LOGGER.exception(
+                "Error while retrieving extended data from valve %s", self._address
+            )
+        else:
+            self._last_success = dt_util.utcnow()
+        finally:
+            with contextlib.suppress(Exception):
+                await client.disconnect()
+
+    async def _async_fetch_device_information(
+        self, client: BaseBleakClient
+    ) -> None:
+        """Retrieve extended diagnostic information from the valve."""
+
+        if self._advertisement is None:
+            return
+
+        _LOGGER.debug(
+            "Connected to valve %s (%s); extended polling not yet implemented",
+            self._address,
+            self._advertisement.model or "unknown model",
+        )
+
+
+class ValveConnectionManager:
+    """Coordinate periodic Bluetooth polling for discovered valves."""
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        discovery_manager: ValveDiscoveryManager,
+    ) -> None:
+        """Initialize the connection manager."""
+
+        self._hass = hass
+        self._discovery_manager = discovery_manager
+        self._connections: dict[str, ValveConnection] = {}
+        self._remove_listener: CALLBACK_TYPE | None = None
+        self._cancel_interval: CALLBACK_TYPE | None = None
+
+    async def async_setup(self) -> None:
+        """Begin tracking valves for periodic polling."""
+
+        for advertisement in self._discovery_manager.devices.values():
+            connection = self._ensure_connection(advertisement)
+            connection.schedule_poll()
+
+        self._remove_listener = self._discovery_manager.async_add_listener(
+            self._handle_discovery_event
+        )
+        self._cancel_interval = async_track_time_interval(
+            self._hass, self._handle_poll_interval, CONNECTION_POLL_INTERVAL
+        )
+
+    async def async_unload(self) -> None:
+        """Cancel scheduled work and disconnect listeners."""
+
+        if self._remove_listener is not None:
+            self._remove_listener()
+            self._remove_listener = None
+
+        if self._cancel_interval is not None:
+            self._cancel_interval()
+            self._cancel_interval = None
+
+        await asyncio.gather(
+            *(connection.async_unload() for connection in self._connections.values()),
+            return_exceptions=True,
+        )
+        self._connections.clear()
+
+    @callback
+    def _handle_poll_interval(self, _: datetime) -> None:
+        """Poll each known valve on a fixed schedule."""
+
+        for connection in self._connections.values():
+            connection.schedule_poll()
+
+    @callback
+    def _handle_discovery_event(
+        self, advertisement: ValveAdvertisement, change: BluetoothChange
+    ) -> None:
+        """React to Bluetooth discovery updates from the passive scanner."""
+
+        if change in BLUETOOTH_LOST_CHANGES:
+            connection = self._connections.get(advertisement.address)
+            if connection is not None:
+                connection.mark_unavailable()
+            return
+
+        connection = self._ensure_connection(advertisement)
+        connection.schedule_poll()
+
+    def _ensure_connection(self, advertisement: ValveAdvertisement) -> ValveConnection:
+        """Return the connection handler for an advertisement's address."""
+
+        connection = self._connections.get(advertisement.address)
+        if connection is None:
+            connection = ValveConnection(self._hass, advertisement.address)
+            self._connections[advertisement.address] = connection
+        connection.update_from_advertisement(advertisement)
+        return connection
+
+    def get_connections(self) -> Iterable[ValveConnection]:
+        """Return an iterable over the tracked valve connections."""
+
+        return self._connections.values()

--- a/custom_components/chandler_legacy_view/connection.py
+++ b/custom_components/chandler_legacy_view/connection.py
@@ -22,6 +22,7 @@ from homeassistant.helpers.event import async_track_time_interval
 from homeassistant.util import dt as dt_util
 
 from .const import CONNECTION_POLL_INTERVAL, CONNECTION_TIMEOUT_SECONDS
+from .device_registry import async_update_device_serial_number
 from .discovery import BLUETOOTH_LOST_CHANGES, ValveDiscoveryManager
 from .models import ValveAdvertisement
 
@@ -502,6 +503,7 @@ class ValveConnection:
                     self._address,
                 )
             self._serial_number = None
+            async_update_device_serial_number(self._hass, self._address, None)
             return
 
         if serial_number != self._serial_number:
@@ -509,6 +511,7 @@ class ValveConnection:
                 "Valve %s reported serial number %s", self._address, serial_number
             )
         self._serial_number = serial_number
+        async_update_device_serial_number(self._hass, self._address, serial_number)
 
     def _extract_serial_number(self, packet: bytes) -> str | None:
         """Return the valve serial number encoded within a DeviceList packet."""

--- a/custom_components/chandler_legacy_view/const.py
+++ b/custom_components/chandler_legacy_view/const.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from datetime import timedelta
 from itertools import product
 from typing import Final
 
@@ -12,6 +13,11 @@ PLATFORMS: Final[list[Platform]] = [Platform.BINARY_SENSOR]
 
 # Storage keys used inside ``hass.data``
 DATA_DISCOVERY_MANAGER: Final = "discovery_manager"
+DATA_CONNECTION_MANAGER: Final = "connection_manager"
+
+# Polling configuration for on-demand Bluetooth connections
+CONNECTION_POLL_INTERVAL: Final = timedelta(minutes=15)
+CONNECTION_TIMEOUT_SECONDS: Final = 20
 
 # Default presentation details for discovered devices
 DEFAULT_FRIENDLY_NAME: Final = "Treatment Valve"

--- a/custom_components/chandler_legacy_view/device_registry.py
+++ b/custom_components/chandler_legacy_view/device_registry.py
@@ -1,0 +1,39 @@
+"""Helpers for updating Home Assistant's device registry."""
+from __future__ import annotations
+
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
+
+from .const import DOMAIN
+
+
+def async_update_device_serial_number(
+    hass: HomeAssistant, address: str, serial_number: str | None
+) -> None:
+    """Update the stored serial number for a valve if it has changed."""
+
+    device_registry = dr.async_get(hass)
+    device_entry = device_registry.async_get_device(identifiers={(DOMAIN, address)})
+    if device_entry is None:
+        return
+
+    if device_entry.serial_number == serial_number:
+        return
+
+    device_registry.async_update_device(device_entry.id, serial_number=serial_number)
+
+
+def async_update_device_sw_version(
+    hass: HomeAssistant, address: str, sw_version: str | None
+) -> None:
+    """Update the stored firmware version for a valve if it has changed."""
+
+    device_registry = dr.async_get(hass)
+    device_entry = device_registry.async_get_device(identifiers={(DOMAIN, address)})
+    if device_entry is None:
+        return
+
+    if device_entry.sw_version == sw_version:
+        return
+
+    device_registry.async_update_device(device_entry.id, sw_version=sw_version)

--- a/custom_components/chandler_legacy_view/discovery.py
+++ b/custom_components/chandler_legacy_view/discovery.py
@@ -16,7 +16,8 @@ from homeassistant.components.bluetooth import (
 from homeassistant.core import CALLBACK_TYPE, HomeAssistant
 
 from .const import CSI_MANUFACTURER_ID, VALVE_MATCHERS, VALVE_NAME_PREFIXES
-from .entity import _is_clack_valve
+from .device_registry import async_update_device_sw_version
+from .entity import _is_clack_valve, format_firmware_version
 from .models import ValveAdvertisement
 
 _LOGGER = logging.getLogger(__name__)
@@ -579,6 +580,11 @@ class ValveDiscoveryManager:
                 connection_counter=classification.connection_counter,
                 bootloader_version=classification.bootloader_version,
                 radio_protocol_version=classification.radio_protocol_version,
+            )
+            async_update_device_sw_version(
+                self._hass,
+                advertisement.address,
+                format_firmware_version(advertisement),
             )
             self._devices[service_info.address] = advertisement
             if classification.firmware_version is not None:


### PR DESCRIPTION
## Summary
- add a valve connection manager that periodically opens active Bluetooth connections so future protocol handlers can fetch extended data
- track the new manager alongside discovery to manage lifecycle and scheduling details
- define polling configuration constants for connection cadence and timeout handling

## Testing
- python -m compileall custom_components/chandler_legacy_view

------
https://chatgpt.com/codex/tasks/task_e_68cd7080d70483338c452a9929467315