### PR TITLE
Add cooldown between valve connection attempts

### DIFF
--- a/custom_components/chandler_legacy_view/const.py
+++ b/custom_components/chandler_legacy_view/const.py
@@ -17,6 +17,7 @@ DATA_CONNECTION_MANAGER: Final = "connection_manager"
 
 # Polling configuration for on-demand Bluetooth connections
 CONNECTION_POLL_INTERVAL: Final = timedelta(minutes=15)
+CONNECTION_MIN_RETRY_INTERVAL: Final = timedelta(seconds=15)
 CONNECTION_TIMEOUT_SECONDS: Final = 20
 
 # Default presentation details for discovered devices


### PR DESCRIPTION
## Summary
- enforce a minimum retry interval between Bluetooth polls
- track cooldown timing in each valve connection and schedule delayed retries when needed

## Testing
- python -m compileall custom_components/chandler_legacy_view

------
https://chatgpt.com/codex/tasks/task_e_68cdb28a5820833385344b792f3e2426