### PR TITLE
Add debug logging for dashboard packet indexing

### DIFF
--- a/custom_components/chandler_legacy_view/connection.py
+++ b/custom_components/chandler_legacy_view/connection.py
@@ -639,6 +639,17 @@ class ValveConnection:
 
             packet = bytes(data)
             index = self._get_dashboard_packet_index(packet, packets)
+            status: str
+            if index is None:
+                status = "ignored"
+            else:
+                status = f"index {index}"
+            _LOGGER.debug(
+                "Valve %s Dashboard packet %s -> %s",
+                self._address,
+                packet.hex(),
+                status,
+            )
             if index is None:
                 return
 


### PR DESCRIPTION
## Summary
- log dashboard notification packets with their assigned index or mark them as ignored when no index is determined

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ce0c8e990c8333b345a3df2cfca244