### PR TITLE
Handle authentication requirement before dashboard requests

### DIFF
--- a/custom_components/chandler_legacy_view/connection.py
+++ b/custom_components/chandler_legacy_view/connection.py
@@ -349,6 +349,13 @@ class ValveConnection:
                 self._address,
             )
 
+        if self._advertisement.authentication_required:
+            _LOGGER.debug(
+                "Skipping Dashboard request to valve %s; authentication is required",
+                self._address,
+            )
+            return
+
         dashboard_request_sent, dashboard_response_received = (
             await self._async_request_dashboard(client)
         )

--- a/custom_components/chandler_legacy_view/discovery.py
+++ b/custom_components/chandler_legacy_view/discovery.py
@@ -183,6 +183,7 @@ class _ManufacturerClassification:
     bootloader_version: int | None = None
     radio_protocol_version: int | None = None
     ignore_advertisement: bool = False
+    authentication_required: bool = False
 
 
 def _has_manufacturer_data_values(value: Any) -> bool:
@@ -358,6 +359,10 @@ def _apply_valve_status(
     """Populate salt, water and bypass status flags from the valve status bits."""
 
     classification.valve_status = valve_status
+    if classification.model == "Evb019":
+        classification.authentication_required = bool(valve_status & 0x01)
+    else:
+        classification.authentication_required = False
     if classification.model == "Evb019":
         classification.salt_sensor_status = 1 if valve_status & 0x02 else 0
         classification.water_status = 1 if valve_status & 0x04 else 0
@@ -579,6 +584,7 @@ class ValveDiscoveryManager:
                 salt_sensor_status=classification.salt_sensor_status,
                 water_status=classification.water_status,
                 bypass_status=classification.bypass_status,
+                authentication_required=classification.authentication_required,
                 valve_error=classification.valve_error,
                 valve_time_hours=classification.valve_time_hours,
                 valve_time_minutes=classification.valve_time_minutes,

--- a/custom_components/chandler_legacy_view/discovery.py
+++ b/custom_components/chandler_legacy_view/discovery.py
@@ -361,13 +361,11 @@ def _apply_valve_status(
     classification.valve_status = valve_status
     if classification.model == "Evb019":
         classification.authentication_required = bool(valve_status & 0x01)
-    else:
-        classification.authentication_required = False
-    if classification.model == "Evb019":
         classification.salt_sensor_status = 1 if valve_status & 0x02 else 0
         classification.water_status = 1 if valve_status & 0x04 else 0
         classification.bypass_status = 1 if valve_status & 0x08 else 0
     else:
+        classification.authentication_required = False
         classification.salt_sensor_status = 1 if valve_status & 0x01 else 0
         classification.water_status = 1 if valve_status & 0x02 else 0
         classification.bypass_status = 1 if valve_status & 0x04 else 0

--- a/custom_components/chandler_legacy_view/models.py
+++ b/custom_components/chandler_legacy_view/models.py
@@ -36,6 +36,7 @@ class ValveAdvertisement:
     connection_counter: int | None = None
     bootloader_version: int | None = None
     radio_protocol_version: int | None = None
+    authentication_required: bool = False
 
 
 @dataclass(slots=True)


### PR DESCRIPTION
## Summary
- track whether an EVB019 advertisement indicates authentication is required
- stop the diagnostic poll from issuing a dashboard request when authentication is needed

## Testing
- python -m compileall custom_components/chandler_legacy_view

------
https://chatgpt.com/codex/tasks/task_e_68ce2b0ef290833396dfa9b27ec6c72d