### PR TITLE
Fix config flow text selector for newer Home Assistant

### DIFF
--- a/custom_components/chandler_legacy_view/config_flow.py
+++ b/custom_components/chandler_legacy_view/config_flow.py
@@ -37,9 +37,6 @@ PASSCODE_PATTERN = re.compile(r"^\d{4}$")
 PASSCODE_SELECTOR = TextSelector(
     TextSelectorConfig(
         type=TextSelectorType.PASSWORD,
-        min=4,
-        max=4,
-        pattern=r"\\d*",
     )
 )
 


### PR DESCRIPTION
## Summary
- remove deprecated configuration options from the passcode text selector so Home Assistant 2024.10+ loads the flow
- continue to validate passcode format server-side

## Testing
- python -m compileall custom_components/chandler_legacy_view

------
https://chatgpt.com/codex/tasks/task_e_68cf59a6c794833385cddc8d78d48292