### PR TITLE
Wait briefly after sending reset packet

### DIFF
--- a/custom_components/chandler_legacy_view/connection.py
+++ b/custom_components/chandler_legacy_view/connection.py
@@ -513,17 +513,26 @@ class ValveConnection:
     ) -> None:
         """Retrieve extended diagnostic information from the valve."""
 
-        if self._advertisement is None:
+        advertisement = self._advertisement
+        if advertisement is None:
             return
 
-        model = self._advertisement.model
-        if model != "Evb019":
+        model = advertisement.model
+        manufacturer_data_complete = advertisement.manufacturer_data_complete
+
+        if model not in (None, "Evb019"):
             _LOGGER.debug(
                 "Connected to valve %s (%s); requests are only defined for Evb019 valves",
                 self._address,
                 model or "unknown model",
             )
             return
+
+        if model is None and not manufacturer_data_complete:
+            _LOGGER.debug(
+                "Valve %s advertisement was incomplete; attempting DeviceList probe",
+                self._address,
+            )
 
         request_sent, response_received = await self._async_request_device_list(client)
         if not request_sent:

--- a/custom_components/chandler_legacy_view/connection.py
+++ b/custom_components/chandler_legacy_view/connection.py
@@ -31,7 +31,10 @@ from .const import (
     CONNECTION_MIN_RETRY_INTERVAL,
     CONNECTION_POLL_INTERVAL,
     CONNECTION_TIMEOUT_SECONDS,
+    DEFAULT_PERSISTENT_POLL_INTERVAL_SECONDS,
     DEFAULT_VALVE_PASSCODE,
+    MAX_PERSISTENT_POLL_INTERVAL_SECONDS,
+    MIN_PERSISTENT_POLL_INTERVAL_SECONDS,
 )
 from .device_registry import async_update_device_serial_number
 from .discovery import BLUETOOTH_LOST_CHANGES, ValveDiscoveryManager
@@ -224,6 +227,9 @@ class ValveConnection:
         self._authentication_listeners: list[Callable[[bool], None]] = []
         self._passcode_getter = passcode_getter
         self._crc8 = _ChandlerCrc8()
+        self._persistent_connection_enabled = False
+        self._persistent_poll_interval = DEFAULT_PERSISTENT_POLL_INTERVAL_SECONDS
+        self._persistent_task: asyncio.Task[None] | None = None
 
     @property
     def address(self) -> str:
@@ -267,6 +273,18 @@ class ValveConnection:
 
         return self._authentication_failed
 
+    @property
+    def persistent_connection_enabled(self) -> bool:
+        """Return ``True`` if persistent connections are currently requested."""
+
+        return self._persistent_connection_enabled
+
+    @property
+    def persistent_poll_interval(self) -> float:
+        """Return the configured persistent poll interval in seconds."""
+
+        return self._persistent_poll_interval
+
     def add_authentication_listener(
         self, listener: Callable[[bool], None]
     ) -> CALLBACK_TYPE:
@@ -306,6 +324,53 @@ class ValveConnection:
             "Valve %s authentication lockout manually cleared", self._address
         )
         self._set_authentication_failed(False)
+
+    async def async_set_persistent_connection_enabled(self, enabled: bool) -> None:
+        """Enable or disable persistent connections for this valve."""
+
+        if enabled:
+            if self._persistent_connection_enabled:
+                return
+            _LOGGER.debug(
+                "Persistent connection requested for valve %s", self._address
+            )
+            self._persistent_connection_enabled = True
+            self._cancel_cooldown()
+            self._next_connection_time = None
+            self.schedule_poll()
+            return
+
+        if not self._persistent_connection_enabled:
+            return
+
+        _LOGGER.debug(
+            "Persistent connection disabled for valve %s", self._address
+        )
+        self._persistent_connection_enabled = False
+        await self._async_stop_persistent_session()
+
+    async def async_set_persistent_poll_interval(self, seconds: float) -> None:
+        """Update the poll interval used during persistent connections."""
+
+        try:
+            value = float(seconds)
+        except (TypeError, ValueError):
+            value = DEFAULT_PERSISTENT_POLL_INTERVAL_SECONDS
+
+        value = max(
+            MIN_PERSISTENT_POLL_INTERVAL_SECONDS,
+            min(value, MAX_PERSISTENT_POLL_INTERVAL_SECONDS),
+        )
+
+        if self._persistent_poll_interval == value:
+            return
+
+        _LOGGER.debug(
+            "Persistent poll interval for valve %s updated to %.1f seconds",
+            self._address,
+            value,
+        )
+        self._persistent_poll_interval = value
 
     def _get_passcode_configuration(self) -> ValvePasscodeConfiguration:
         """Return the stored passcode configuration for this valve."""
@@ -399,11 +464,155 @@ class ValveConnection:
         if self.available:
             self.schedule_poll()
 
+    def _persistent_task_active(self) -> bool:
+        """Return ``True`` if a persistent session is currently running."""
+
+        task = self._persistent_task
+        if task is None:
+            return False
+        if task.done():
+            with contextlib.suppress(Exception):
+                task.result()
+            self._persistent_task = None
+            return False
+        return True
+
+    async def _async_stop_persistent_session(self) -> None:
+        """Cancel the persistent polling session if one is active."""
+
+        task = self._persistent_task
+        if task is None:
+            return
+
+        task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await task
+        self._persistent_task = None
+
+    def _can_start_persistent_session(self) -> bool:
+        """Return ``True`` if a persistent session may be started."""
+
+        if not self._persistent_connection_enabled or self._unloaded:
+            return False
+
+        if self._persistent_task_active():
+            return False
+
+        advertisement = self._advertisement
+        if advertisement is not None and not advertisement.authentication_required:
+            return True
+
+        return (
+            self._device_list_authentication_state
+            == ValveAuthenticationState.AUTHENTICATED
+        )
+
+    def _try_begin_persistent_session(self, client: BaseBleakClient) -> bool:
+        """Start a persistent polling session if conditions allow."""
+
+        if not self._can_start_persistent_session():
+            return False
+
+        _LOGGER.debug(
+            "Maintaining persistent connection to valve %s", self._address
+        )
+        self._persistent_task = self._hass.loop.create_task(
+            self._async_persistent_keepalive_loop(client)
+        )
+        return True
+
+    async def _async_persistent_keepalive_loop(
+        self, client: BaseBleakClient
+    ) -> None:
+        """Keep the BLE connection alive and poll on a frequent schedule."""
+
+        try:
+            while True:
+                if (
+                    not self._persistent_connection_enabled
+                    or self._unloaded
+                    or not getattr(client, "is_connected", False)
+                ):
+                    break
+
+                interval = max(
+                    MIN_PERSISTENT_POLL_INTERVAL_SECONDS,
+                    min(
+                        self._persistent_poll_interval,
+                        MAX_PERSISTENT_POLL_INTERVAL_SECONDS,
+                    ),
+                )
+
+                try:
+                    await asyncio.sleep(interval)
+                except asyncio.CancelledError:
+                    raise
+
+                if (
+                    not self._persistent_connection_enabled
+                    or self._unloaded
+                    or not getattr(client, "is_connected", False)
+                ):
+                    break
+
+                try:
+                    request_sent, response_received = (
+                        await self._async_request_dashboard(client)
+                    )
+                except asyncio.CancelledError:
+                    raise
+                except Exception:  # pragma: no cover - unexpected protocol errors
+                    _LOGGER.exception(
+                        "Unexpected error while refreshing dashboard data for valve %s",
+                        self._address,
+                    )
+                    break
+
+                if not request_sent:
+                    _LOGGER.debug(
+                        "Stopping persistent polling for valve %s; unable to send Dashboard request",
+                        self._address,
+                    )
+                    break
+
+                if response_received:
+                    self._last_success = dt_util.utcnow()
+                else:
+                    _LOGGER.debug(
+                        "Valve %s did not provide a Dashboard response during persistent polling",
+                        self._address,
+                    )
+                    break
+        except asyncio.CancelledError:
+            _LOGGER.debug(
+                "Persistent polling task for valve %s was cancelled", self._address
+            )
+            raise
+        finally:
+            reset_packet_sent = False
+            with contextlib.suppress(Exception):
+                reset_packet_sent = await self._async_send_reset_buffer_packet(client)
+            if reset_packet_sent:
+                await asyncio.sleep(0.1)
+            with contextlib.suppress(Exception):
+                await client.disconnect()
+
+            self._persistent_task = None
+
+            if (
+                self._persistent_connection_enabled
+                and not self._unloaded
+            ):
+                self._set_connection_cooldown()
+                self.schedule_poll()
+
     async def async_unload(self) -> None:
         """Prevent future polls and wait for any active poll to finish."""
 
         self._unloaded = True
+        self._persistent_connection_enabled = False
         self._cancel_cooldown()
+        await self._async_stop_persistent_session()
         async with self._lock:
             return
 
@@ -411,6 +620,14 @@ class ValveConnection:
         """Attempt to connect to the valve and fetch additional data."""
 
         if not self.available:
+            return
+
+        task_active = self._persistent_task_active()
+        if self._persistent_connection_enabled and task_active:
+            _LOGGER.debug(
+                "Skipping poll for %s; persistent session is already active",
+                self._address,
+            )
             return
 
         if self._lock.locked():
@@ -438,6 +655,7 @@ class ValveConnection:
             return
 
         connection_attempted = False
+        cleanup_client: BaseBleakClient | None = None
 
         try:
             advertisement = self._advertisement
@@ -488,6 +706,8 @@ class ValveConnection:
                 )
                 return
 
+            cleanup_client = client
+
             try:
                 await self._async_fetch_device_information(client)
             except Exception:  # pragma: no cover - future protocol work may raise
@@ -496,14 +716,19 @@ class ValveConnection:
                 )
             else:
                 self._last_success = dt_util.utcnow()
+                if self._try_begin_persistent_session(client):
+                    cleanup_client = None
             finally:
-                reset_packet_sent = False
-                with contextlib.suppress(Exception):
-                    reset_packet_sent = await self._async_send_reset_buffer_packet(client)
-                if reset_packet_sent:
-                    await asyncio.sleep(0.1)
-                with contextlib.suppress(Exception):
-                    await client.disconnect()
+                if cleanup_client is not None:
+                    reset_packet_sent = False
+                    with contextlib.suppress(Exception):
+                        reset_packet_sent = await self._async_send_reset_buffer_packet(
+                            cleanup_client
+                        )
+                    if reset_packet_sent:
+                        await asyncio.sleep(0.1)
+                    with contextlib.suppress(Exception):
+                        await cleanup_client.disconnect()
         finally:
             if connection_attempted:
                 self._set_connection_cooldown()

--- a/custom_components/chandler_legacy_view/const.py
+++ b/custom_components/chandler_legacy_view/const.py
@@ -29,7 +29,7 @@ DATA_CONNECTION_MANAGER: Final = "connection_manager"
 
 # Polling configuration for on-demand Bluetooth connections
 CONNECTION_POLL_INTERVAL: Final = timedelta(minutes=15)
-CONNECTION_MIN_RETRY_INTERVAL: Final = timedelta(seconds=15)
+CONNECTION_MIN_RETRY_INTERVAL: Final = timedelta(seconds=30)
 CONNECTION_TIMEOUT_SECONDS: Final = 20
 
 # Default presentation details for discovered devices

--- a/custom_components/chandler_legacy_view/const.py
+++ b/custom_components/chandler_legacy_view/const.py
@@ -19,9 +19,15 @@ DEFAULT_VALVE_PASSCODE: Final = "1234"
 DOMAIN: Final = "chandler_legacy_view"
 PLATFORMS: Final[list[Platform]] = [
     Platform.BINARY_SENSOR,
+    Platform.NUMBER,
     Platform.SENSOR,
     Platform.SWITCH,
 ]
+
+# Persistent connection configuration
+DEFAULT_PERSISTENT_POLL_INTERVAL_SECONDS: Final = 10.0
+MIN_PERSISTENT_POLL_INTERVAL_SECONDS: Final = 5.0
+MAX_PERSISTENT_POLL_INTERVAL_SECONDS: Final = 300.0
 
 # Storage keys used inside ``hass.data``
 DATA_DISCOVERY_MANAGER: Final = "discovery_manager"

--- a/custom_components/chandler_legacy_view/discovery.py
+++ b/custom_components/chandler_legacy_view/discovery.py
@@ -413,9 +413,9 @@ def _apply_valve_status(
         classification.bypass_status = 1 if valve_status & 0x08 else 0
     else:
         classification.authentication_required = False
-        classification.salt_sensor_status = 1 if valve_status & 0x01 else 0
-        classification.water_status = 1 if valve_status & 0x02 else 0
-        classification.bypass_status = 1 if valve_status & 0x04 else 0
+        classification.salt_sensor_status = 1 if valve_status & 0x80 else 0
+        classification.water_status = 1 if valve_status & 0x40 else 0
+        classification.bypass_status = 1 if valve_status & 0x20 else 0
 
 
 def _parse_evb034_payload(

--- a/custom_components/chandler_legacy_view/models.py
+++ b/custom_components/chandler_legacy_view/models.py
@@ -23,6 +23,7 @@ class ValveAdvertisement:
     is_400_series: bool = False
     has_connection_counter: bool = False
     valve_data_parsed: bool = False
+    manufacturer_data_complete: bool = True
     valve_status: int | None = None
     salt_sensor_status: int | None = None
     water_status: int | None = None

--- a/custom_components/chandler_legacy_view/number.py
+++ b/custom_components/chandler_legacy_view/number.py
@@ -1,0 +1,144 @@
+"""Number entities for configuring Chandler valves."""
+
+from __future__ import annotations
+
+import logging
+
+from homeassistant.components.bluetooth import BluetoothChange
+from homeassistant.components.number import NumberEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import UnitOfTime
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.entity import EntityCategory
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import (
+    DATA_CONNECTION_MANAGER,
+    DATA_DISCOVERY_MANAGER,
+    DOMAIN,
+    MAX_PERSISTENT_POLL_INTERVAL_SECONDS,
+    MIN_PERSISTENT_POLL_INTERVAL_SECONDS,
+)
+from .connection import ValveConnection, ValveConnectionManager
+from .discovery import BLUETOOTH_LOST_CHANGES, ValveDiscoveryManager
+from .entity import ChandlerValveEntity
+from .models import ValveAdvertisement
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class ValvePersistentPollIntervalNumber(ChandlerValveEntity, NumberEntity):
+    """Configure the polling interval used while a persistent connection is active."""
+
+    _attr_entity_category = EntityCategory.CONFIG
+    _attr_native_unit_of_measurement = UnitOfTime.SECONDS
+    _attr_native_min_value = MIN_PERSISTENT_POLL_INTERVAL_SECONDS
+    _attr_native_max_value = MAX_PERSISTENT_POLL_INTERVAL_SECONDS
+    _attr_native_step = 1.0
+
+    def __init__(
+        self, advertisement: ValveAdvertisement, connection: ValveConnection
+    ) -> None:
+        super().__init__(advertisement)
+        self._connection = connection
+        self._attr_unique_id = f"{advertisement.address}_persistent_poll_interval"
+        self._attr_name = f"{self._attr_name} Persistent Poll Interval"
+        self._attr_available = True
+        self._attr_native_value = connection.persistent_poll_interval
+
+    @callback
+    def async_handle_bluetooth_update(
+        self, advertisement: ValveAdvertisement, change: BluetoothChange
+    ) -> None:
+        """Handle Bluetooth discovery updates for the valve."""
+
+        if change in BLUETOOTH_LOST_CHANGES:
+            self._attr_available = False
+        else:
+            self.async_update_from_advertisement(advertisement)
+            self._attr_available = True
+
+        self._attr_native_value = self._connection.persistent_poll_interval
+        if self.hass is not None:
+            self.async_write_ha_state()
+
+    def async_update_from_advertisement(
+        self, advertisement: ValveAdvertisement
+    ) -> None:
+        """Store the latest advertisement details for the valve."""
+
+        super().async_update_from_advertisement(advertisement)
+        self._attr_name = f"{self._attr_name} Persistent Poll Interval"
+
+    async def async_set_native_value(self, value: float) -> None:
+        """Update the configured persistent polling interval."""
+
+        await self._connection.async_set_persistent_poll_interval(value)
+        self._attr_native_value = self._connection.persistent_poll_interval
+        if self.hass is not None:
+            self.async_write_ha_state()
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up persistent poll interval numbers for Chandler valves."""
+
+    entry_data = hass.data[DOMAIN][entry.entry_id]
+    discovery_manager: ValveDiscoveryManager = entry_data[DATA_DISCOVERY_MANAGER]
+    connection_manager: ValveConnectionManager = entry_data[DATA_CONNECTION_MANAGER]
+
+    entities: dict[str, ValvePersistentPollIntervalNumber] = {}
+
+    def _ensure_entity(
+        advertisement: ValveAdvertisement,
+    ) -> tuple[ValvePersistentPollIntervalNumber | None, list[ValvePersistentPollIntervalNumber]]:
+        entity = entities.get(advertisement.address)
+        new_entities: list[ValvePersistentPollIntervalNumber] = []
+
+        if entity is None:
+            connection = connection_manager.get_connection(advertisement.address)
+            if connection is None:
+                _LOGGER.debug(
+                    "Delaying persistent poll interval entity creation for %s; connection not ready",
+                    advertisement.address,
+                )
+                return None, new_entities
+
+            entity = ValvePersistentPollIntervalNumber(advertisement, connection)
+            entities[advertisement.address] = entity
+            new_entities.append(entity)
+
+        return entity, new_entities
+
+    initial_entities: list[ValvePersistentPollIntervalNumber] = []
+    for advertisement in discovery_manager.devices.values():
+        _, new_entities = _ensure_entity(advertisement)
+        initial_entities.extend(new_entities)
+
+    if initial_entities:
+        async_add_entities(initial_entities)
+
+    @callback
+    def _handle_discovery(
+        advertisement: ValveAdvertisement, change: BluetoothChange
+    ) -> None:
+        if change in BLUETOOTH_LOST_CHANGES:
+            entity = entities.get(advertisement.address)
+            if entity is not None:
+                entity.async_handle_bluetooth_update(advertisement, change)
+            return
+
+        entity, new_entities = _ensure_entity(advertisement)
+        if entity is None:
+            return
+
+        if new_entities:
+            async_add_entities(new_entities)
+
+        entity.async_handle_bluetooth_update(advertisement, change)
+
+    remove_listener = discovery_manager.async_add_listener(_handle_discovery)
+    entry.async_on_unload(remove_listener)


### PR DESCRIPTION
## Summary
- update the reset-buffer helper to report whether a packet was sent
- pause for 100 ms after successfully sending a reset packet before disconnecting the BLE client

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d190a8cf7c8333ab14634bfa8a80d6