### PR TITLE
Fix water hardness unit definition

### DIFF
--- a/custom_components/chandler_legacy_view/sensor.py
+++ b/custom_components/chandler_legacy_view/sensor.py
@@ -17,8 +17,11 @@ from homeassistant.const import (
     UnitOfTime,
     UnitOfVolume,
     UnitOfVolumeFlowRate,
-    UnitOfWaterHardness,
 )
+
+# Home Assistant does not currently expose a dedicated water hardness unit
+# constant, so we keep using the unit string Chandler devices report.
+WATER_HARDNESS_GRAINS_PER_GALLON = "grains_per_gallon"
 from homeassistant.core import CALLBACK_TYPE, HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.util import dt as dt_util
@@ -153,7 +156,7 @@ class ValvePresentFlowSensor(ValveDashboardSensor):
 class ValveWaterHardnessSensor(ValveDashboardSensor):
     """Represent the configured water hardness reported by a valve."""
 
-    _attr_native_unit_of_measurement = UnitOfWaterHardness.GRAINS_PER_GALLON
+    _attr_native_unit_of_measurement = WATER_HARDNESS_GRAINS_PER_GALLON
     _attr_state_class = SensorStateClass.MEASUREMENT
 
     def __init__(


### PR DESCRIPTION
## Summary
- remove the import of the nonexistent `UnitOfWaterHardness` constant
- define the grains-per-gallon unit string locally so the water hardness sensor retains its native units

## Testing
- python -m compileall custom_components/chandler_legacy_view

------
https://chatgpt.com/codex/tasks/task_e_68d1f9c0142c83338b57ef0a02094d7e