### PR TITLE
Connection cleanup

### DIFF
--- a/custom_components/chandler_legacy_view/__init__.py
+++ b/custom_components/chandler_legacy_view/__init__.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import EVENT_HOMEASSISTANT_STOP
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.device_registry import DeviceEntryType
@@ -74,6 +75,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
+    async def _handle_stop(_: object) -> None:
+        await connection_manager.async_shutdown()
+
+    entry.async_on_unload(
+        hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, _handle_stop)
+    )
     entry.async_on_unload(entry.add_update_listener(async_reload_entry))
     _LOGGER.debug("Chandler Legacy View setup complete for entry %s", entry.entry_id)
     return True

--- a/custom_components/chandler_legacy_view/connection.py
+++ b/custom_components/chandler_legacy_view/connection.py
@@ -2216,6 +2216,11 @@ class ValveConnectionManager:
         )
         self._connections.clear()
 
+    async def async_shutdown(self) -> None:
+        """Best-effort cleanup when Home Assistant stops."""
+
+        await asyncio.shield(self.async_unload())
+
     @callback
     def _handle_poll_interval(self, _: datetime) -> None:
         """Poll each known valve on a fixed schedule."""


### PR DESCRIPTION
PR Summary
- Ensures BLE disconnects are cancellation-safe by shielding cleanup and reusing a single disconnect helper in both persistent and one-shot poll paths.
- Adds a Home Assistant stop hook to trigger best-effort connection cleanup during shutdown, preventing the ESP32 proxy from keeping stale connections open.

Why
- Restarting Home Assistant could cancel in-flight BLE tasks before disconnect() ran, leaving the proxy stuck with open connections.

Testing
- Not run (recommend restarting Home Assistant and verifying the ESP32 proxy releases connections during shutdown).
