### PR TITLE
feat:  add bluetooth connection and additional device_classes to sensors

### DIFF
--- a/custom_components/chandler_legacy_view/entity.py
+++ b/custom_components/chandler_legacy_view/entity.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 
+from homeassistant.helpers.device_registry import CONNECTION_BLUETOOTH
 from homeassistant.helpers.entity import DeviceInfo, Entity
 
 from .const import (
@@ -128,7 +129,11 @@ def _valve_error_display(error_code: int | None, is_clack_valve: bool) -> str | 
     if error_code is None:
         return None
     if error_code == _VALVE_ERROR_TIMEOUT_CODE:
-        return "Drive 1 motor timeout error" if is_clack_valve else "TWEDO motor timeout error"
+        return (
+            "Drive 1 motor timeout error"
+            if is_clack_valve
+            else "TWEDO motor timeout error"
+        )
     return _VALVE_ERROR_DISPLAY.get(error_code)
 
 
@@ -195,10 +200,7 @@ def format_firmware_version(advertisement: ValveAdvertisement) -> str | None:
 
     firmware_version = advertisement.firmware_version
     if firmware_version is None:
-        if (
-            advertisement.firmware_major is None
-            or advertisement.firmware_minor is None
-        ):
+        if advertisement.firmware_major is None or advertisement.firmware_minor is None:
             return None
         firmware_version = (
             advertisement.firmware_major * 100 + advertisement.firmware_minor
@@ -232,13 +234,16 @@ class ChandlerValveEntity(Entity):
         return DeviceInfo(
             identifiers={(DOMAIN, self._advertisement.address)},
             name=self._compute_name(self._advertisement),
+            connections={(CONNECTION_BLUETOOTH, self._advertisement.address)},
             manufacturer=DEFAULT_MANUFACTURER,
             model=self._advertisement.model,
             via_device=(DOMAIN, DISCOVERY_VIA_DEVICE_ID),
             sw_version=format_firmware_version(self._advertisement),
         )
 
-    def async_update_from_advertisement(self, advertisement: ValveAdvertisement) -> None:
+    def async_update_from_advertisement(
+        self, advertisement: ValveAdvertisement
+    ) -> None:
         """Store the most recent advertisement seen for this valve."""
 
         self._advertisement = advertisement
@@ -248,4 +253,3 @@ class ChandlerValveEntity(Entity):
         """Generate a user-friendly name for the valve entity."""
 
         return friendly_name_from_advertised_name(advertisement.name)
-

--- a/custom_components/chandler_legacy_view/sensor.py
+++ b/custom_components/chandler_legacy_view/sensor.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-import logging
 from collections.abc import Callable
+import logging
 
 from homeassistant.components.bluetooth import BluetoothChange
 from homeassistant.components.sensor import (
@@ -18,21 +18,21 @@ from homeassistant.const import (
     UnitOfVolume,
     UnitOfVolumeFlowRate,
 )
-
-# Home Assistant does not currently expose a dedicated water hardness unit
-# constant, so we keep using the unit string Chandler devices report.
-WATER_HARDNESS_GRAINS_PER_GALLON = "grains_per_gallon"
 from homeassistant.core import CALLBACK_TYPE, HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.util import dt as dt_util
 
-from .const import DATA_CONNECTION_MANAGER, DATA_DISCOVERY_MANAGER, DOMAIN
 from .connection import ValveConnection, ValveConnectionManager
+from .const import DATA_CONNECTION_MANAGER, DATA_DISCOVERY_MANAGER, DOMAIN
 from .discovery import BLUETOOTH_LOST_CHANGES, ValveDiscoveryManager
 from .entity import ChandlerValveEntity, _is_clack_valve
 from .models import ValveAdvertisement, ValveDashboardData
 
 _LOGGER = logging.getLogger(__name__)
+
+# Home Assistant does not currently expose a dedicated water hardness unit
+# constant, so we keep using the unit string Chandler devices report.
+WATER_HARDNESS_GRAINS_PER_GALLON = "grains_per_gallon"
 
 
 class ValveDashboardSensor(ChandlerValveEntity, SensorEntity):
@@ -121,9 +121,7 @@ class ValveDashboardSensor(ChandlerValveEntity, SensorEntity):
         raise NotImplementedError
 
     @callback
-    def _handle_dashboard_update(
-        self, dashboard: ValveDashboardData | None
-    ) -> None:
+    def _handle_dashboard_update(self, dashboard: ValveDashboardData | None) -> None:
         """Handle updates from the dashboard poller."""
 
         self._update_from_dashboard(dashboard, write_state=True)
@@ -134,6 +132,7 @@ class ValvePresentFlowSensor(ValveDashboardSensor):
 
     _attr_native_unit_of_measurement = UnitOfVolumeFlowRate.GALLONS_PER_MINUTE
     _attr_state_class = SensorStateClass.MEASUREMENT
+    _attr_device_class = SensorDeviceClass.VOLUME_FLOW_RATE
 
     def __init__(
         self, advertisement: ValveAdvertisement, connection: ValveConnection
@@ -169,9 +168,7 @@ class ValveWaterHardnessSensor(ValveDashboardSensor):
             name_suffix="Water Hardness",
         )
 
-    def _extract_native_value(
-        self, dashboard: ValveDashboardData | None
-    ) -> int | None:
+    def _extract_native_value(self, dashboard: ValveDashboardData | None) -> int | None:
         if dashboard is None:
             return None
         return dashboard.water_hardness
@@ -233,9 +230,7 @@ class ValveBatteryCapacitySensor(ValveDashboardSensor):
             name_suffix="Battery",
         )
 
-    def _extract_native_value(
-        self, dashboard: ValveDashboardData | None
-    ) -> int | None:
+    def _extract_native_value(self, dashboard: ValveDashboardData | None) -> int | None:
         if dashboard is None:
             return None
         return dashboard.battery_capacity
@@ -246,6 +241,7 @@ class ValveSoftWaterRemainingSensor(ValveDashboardSensor):
 
     _attr_native_unit_of_measurement = UnitOfVolume.GALLONS
     _attr_state_class = SensorStateClass.MEASUREMENT
+    _attr_device_class = SensorDeviceClass.WATER
 
     def __init__(
         self, advertisement: ValveAdvertisement, connection: ValveConnection
@@ -257,9 +253,7 @@ class ValveSoftWaterRemainingSensor(ValveDashboardSensor):
             name_suffix="Soft Water Remaining",
         )
 
-    def _extract_native_value(
-        self, dashboard: ValveDashboardData | None
-    ) -> int | None:
+    def _extract_native_value(self, dashboard: ValveDashboardData | None) -> int | None:
         if dashboard is None:
             return None
         return dashboard.water_remaining_until_regeneration
@@ -270,6 +264,7 @@ class ValveDaysUntilRegenerationSensor(ValveDashboardSensor):
 
     _attr_native_unit_of_measurement = UnitOfTime.DAYS
     _attr_state_class = SensorStateClass.MEASUREMENT
+    _attr_device_class = SensorDeviceClass.DURATION
 
     def __init__(
         self, advertisement: ValveAdvertisement, connection: ValveConnection
@@ -286,9 +281,7 @@ class ValveDaysUntilRegenerationSensor(ValveDashboardSensor):
             return "Days Until Regeneration"
         return "Days Until Backwash"
 
-    def _extract_native_value(
-        self, dashboard: ValveDashboardData | None
-    ) -> int | None:
+    def _extract_native_value(self, dashboard: ValveDashboardData | None) -> int | None:
         if dashboard is None:
             return None
         return dashboard.air_recharge
@@ -299,6 +292,7 @@ class ValveWaterUsageTodaySensor(ValveDashboardSensor):
 
     _attr_native_unit_of_measurement = UnitOfVolume.GALLONS
     _attr_state_class = SensorStateClass.MEASUREMENT
+    _attr_device_class = SensorDeviceClass.WATER
 
     def __init__(
         self, advertisement: ValveAdvertisement, connection: ValveConnection
@@ -310,9 +304,7 @@ class ValveWaterUsageTodaySensor(ValveDashboardSensor):
             name_suffix="Water Usage Today",
         )
 
-    def _extract_native_value(
-        self, dashboard: ValveDashboardData | None
-    ) -> int | None:
+    def _extract_native_value(self, dashboard: ValveDashboardData | None) -> int | None:
         if dashboard is None:
             return None
         return dashboard.water_usage
@@ -323,6 +315,7 @@ class ValvePeakFlowTodaySensor(ValveDashboardSensor):
 
     _attr_native_unit_of_measurement = UnitOfVolumeFlowRate.GALLONS_PER_MINUTE
     _attr_state_class = SensorStateClass.MEASUREMENT
+    _attr_device_class = SensorDeviceClass.VOLUME_FLOW_RATE
 
     def __init__(
         self, advertisement: ValveAdvertisement, connection: ValveConnection
@@ -523,7 +516,9 @@ async def async_setup_entry(
                     entity.async_handle_bluetooth_update(advertisement, change)
             return
 
-        results = [ensure_callback(advertisement) for ensure_callback in ensure_callbacks]
+        results = [
+            ensure_callback(advertisement) for ensure_callback in ensure_callbacks
+        ]
 
         new_entities: list[SensorEntity] = []
         for _, created in results:


### PR DESCRIPTION
Adds bluetooth connection to device info so bluetooth device now will appear associated with a proxy in the HA bluetooth dashboard (`/config/bluetooth/advertisement-monitor`).

Add device classes of `WATER` and `VOLUME_FLOW_RATE` to sensors so these can be used in "pickers" or added to the energy dashboard.